### PR TITLE
#158626102 Make translations of exercises and ingredients easier 

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -65,7 +65,7 @@ $(document).ready(function() {
 -->
 {% block content %}
 
-{% cache 1 exercise-overview language.id %}
+{% cache cache_timeout exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}

--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -8,7 +8,34 @@
 <!--
         Title
 -->
-{% block title %}{% trans "Exercises" %}{% endblock %}
+{% block title %}
+{% trans "Exercises" %}
+<div class="btn-group" style="float: right;">
+    <button type="button" class="btn btn-success dropdown-toggle btn-sm" data-toggle="dropdown">
+        {% trans 'Filter by language' %}
+        <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li>
+            <a href={% url 'exercise:exercise:overview' %}>None
+        </li>
+        {% for code, language in languages %}
+        <li>
+            <a href={% url 'exercise:exercise:overview' %}?lang={{code}}>{{language}}
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+<div class="btn-group">
+    <button type="button" class="btn btn-primary btn-sm" disabled>
+        {% if lang %}
+        {{lang.full_name}}
+        {% else %}
+        ALL Languages
+        {% endif %}
+    </button>
+</div>
+{% endblock %}
 
 
 
@@ -38,7 +65,7 @@ $(document).ready(function() {
 -->
 {% block content %}
 
-{% cache cache_timeout exercise-overview language.id %}
+{% cache 1 exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -82,8 +82,8 @@ class ExerciseIndexTestCase(WorkoutManagerTestCase):
         self.assertEqual(category_1.name, "Another category")
 
         category_2 = response.context['exercises'][1].category
-        self.assertEqual(category_2.id, 3)
-        self.assertEqual(category_2.name, "Yet another category")
+        self.assertEqual(category_2.id, 2)
+        self.assertEqual(category_2.name, "Another category")
 
         # Correct exercises in the categories
         exercises_1 = category_1.exercise_set.all()

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -61,10 +61,10 @@ class ExerciseListView(ListView):
         Filter to only active exercises in the configured languages
         '''
         language = None
-        lg_code = self.request.GET.get('lang', None)
+        language_code = self.request.GET.get('lang', None)
         
-        if lg_code:
-            lang = Language.objects.filter(short_name=lg_code)
+        if language_code:
+            lang = Language.objects.filter(short_name=language_code)
             if lang.exists():
                 language = lang.first().id
 
@@ -88,10 +88,10 @@ class ExerciseListView(ListView):
         return context
 
     def get_filter_language(self):
-        lg_code = self.request.GET.get('lang', None)
+        language_code = self.request.GET.get('lang', None)
         lang = None
-        if lg_code:
-            lang = Language.objects.get(short_name=lg_code)
+        if language_code:
+            lang = Language.objects.get(short_name=language_code)
         return lang
 
 def view(request, id, slug=None):

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -33,6 +33,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from django.views.generic import (ListView, DeleteView, CreateView, UpdateView)
 
+from wger.core.models import Language
 from wger.manager.models import WorkoutLog
 from wger.exercises.models import (Exercise, Muscle, ExerciseCategory)
 from wger.utils.generic_views import (WgerFormMixin, WgerDeleteMixin)
@@ -59,9 +60,21 @@ class ExerciseListView(ListView):
         '''
         Filter to only active exercises in the configured languages
         '''
-        languages = load_item_languages(LanguageConfig.SHOW_ITEM_EXERCISES)
+        language = None
+        lg_code = self.request.GET.get('lang', None)
+        
+        if lg_code:
+            lang = Language.objects.filter(short_name=lg_code)
+            if lang.exists():
+                language = lang.first().id
+
+        if language:
+            return Exercise.objects.accepted() \
+            .filter(language=language) \
+            .order_by('category__id') \
+            .select_related()
+
         return Exercise.objects.accepted() \
-            .filter(language__in=languages) \
             .order_by('category__id') \
             .select_related()
 
@@ -71,8 +84,15 @@ class ExerciseListView(ListView):
         '''
         context = super(ExerciseListView, self).get_context_data(**kwargs)
         context['show_shariff'] = True
+        context['lang'] = self.get_filter_language()
         return context
 
+    def get_filter_language(self):
+        lg_code = self.request.GET.get('lang', None)
+        lang = None
+        if lg_code:
+            lang = Language.objects.get(short_name=lg_code)
+        return lang
 
 def view(request, id, slug=None):
     '''

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -26,7 +26,34 @@
     </script>
 {% endblock %}
 
-{% block title %}{% trans "Ingredient overview" %}{% endblock %}
+{% block title %}
+{% trans "Ingredient overview" %}
+<div class="btn-group" style="float: right;">
+    <button type="button" class="btn btn-success dropdown-toggle btn-sm" data-toggle="dropdown">
+        {% trans 'Filter by language' %}
+        <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li>
+            <a href={% url 'nutrition:ingredient:list' %}>None
+        </li>
+        {% for code, language in languages %}
+        <li>
+            <a href={% url 'nutrition:ingredient:list' %}?lang={{code}}>{{language}}
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+<div class="btn-group">
+    <button type="button" class="btn btn-primary btn-sm" disabled>
+        {% if lang %}
+        {{lang.full_name}}
+        {% else %}
+        ALL Languages
+        {% endif %}
+    </button>
+</div>
+{% endblock %}
 
 
 {% block content %}

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -58,9 +58,9 @@ class IngredientListView(ListView):
         his native language, see load_ingredient_languages)
         '''
         language = None
-        lg_code = self.request.GET.get('lang', None)
-        if lg_code:
-            lang = Language.objects.filter(short_name=lg_code)
+        language_code = self.request.GET.get('lang', None)
+        if language_code:
+            lang = Language.objects.filter(short_name=language_code)
             if lang.exists():
                 language = lang.first().id
 
@@ -81,10 +81,10 @@ class IngredientListView(ListView):
         return context
 
     def get_filter_language(self):
-        lg_code = self.request.GET.get('lang', None)
+        language_code = self.request.GET.get('lang', None)
         lang = None
-        if lg_code:
-            lang = Language.objects.get(short_name=lg_code)
+        if language_code:
+            lang = Language.objects.get(short_name=language_code)
         return lang
 
 def view(request, id, slug=None):


### PR DESCRIPTION
#### What does this PR do?
Adds a feature that enables exercises and ingredients be filtered based on the language they were created in.

#### How should this be manually tested?
- Log in to the wger application
- Visit the exercise menu on the exercise tab and ingredients overview in the nutrition tab
- To Filter by language click the drop-down menu and chose your preferred language from the drop-down list of languages.
- The available exercises and Ingredients should then be filtered to correspond to the chosen language.
- To run the fixed tests locally `./manage.py test wger.exercises`

##### What are the relevant pivotal tracker stories?
[Make translations of exercises and ingredients easier ](https://www.pivotaltracker.com/story/show/158626102)

#### Screenshots
![image](https://user-images.githubusercontent.com/22454909/42557964-90dedd5a-84f8-11e8-863b-a39eeeb4edea.png)
![image](https://user-images.githubusercontent.com/22454909/42557990-9e62f042-84f8-11e8-92b0-5ebb347cddfa.png)
![image](https://user-images.githubusercontent.com/22454909/42558027-b716f0de-84f8-11e8-987d-562bdeb2e5e9.png)
![image](https://user-images.githubusercontent.com/22454909/42558064-cfddd330-84f8-11e8-9180-31447c9e2b5e.png)

