### PR TITLE
[Feature #158626097] Show all infos for an exercise

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,9 @@ django-formtools>=1.0,<1.1
 bleach
 python-mimeparse
 pillow
-flake8
+flake8==3.5.0
 autopep8
-pycodestyle
+pycodestyle==2.3.1
 yapf
 easy-thumbnails
 django_compressor

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -46,7 +46,7 @@ class ExerciseInfoSerializer(serializers.ModelSerializer):
     Exercise info serialiser
     '''
 
-    image = serializers.StringRelatedField(
+    exercise_images_list = serializers.StringRelatedField(
         source='get_exercise_image', many=True
     )
     description = serializers.ReadOnlyField(source='description_clean')
@@ -54,8 +54,9 @@ class ExerciseInfoSerializer(serializers.ModelSerializer):
     class Meta:
         model = Exercise
         fields = ('id', 'name', 'name_original', 'category', 'equipment',
-                  'description', 'muscles', 'muscles_secondary', 'image',
-                  'language', 'license', 'license_author', 'creation_date')
+                  'description', 'muscles', 'muscles_secondary',
+                  'exercise_images_list', 'language', 'license',
+                  'license_author', 'creation_date')
 
 
 class ExerciseCategorySerializer(serializers.ModelSerializer):

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -23,7 +23,6 @@ from wger.exercises.models import (
     Equipment,
     ExerciseComment
 )
-from wger.core.api.serializers import LicenseSerializer, LanguageSerializer
 
 
 class ExerciseSerializer(serializers.ModelSerializer):

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -15,16 +15,21 @@
 # You should have received a copy of the GNU Affero General Public License
 
 from rest_framework import serializers
-from wger.exercises.models import (Muscle, Exercise, ExerciseImage,
-                                   ExerciseCategory, Equipment,
-                                   ExerciseComment)
+from wger.exercises.models import (
+    Muscle,
+    Exercise,
+    ExerciseImage,
+    ExerciseCategory,
+    Equipment,
+    ExerciseComment
+)
+from wger.core.api.serializers import LicenseSerializer, LanguageSerializer
 
 
 class ExerciseSerializer(serializers.ModelSerializer):
     '''
     Exercise serializer
     '''
-
     class Meta:
         model = Exercise
 
@@ -33,16 +38,23 @@ class EquipmentSerializer(serializers.ModelSerializer):
     '''
     Equipment serializer
     '''
-
     class Meta:
         model = Equipment
+
+
+class ExerciseInfoSerializer(serializers.ModelSerializer):
+    '''
+    Exercise info serialiser
+    '''
+
+    class Meta:
+        model = Exercise
 
 
 class ExerciseCategorySerializer(serializers.ModelSerializer):
     '''
     ExerciseCategory serializer
     '''
-
     class Meta:
         model = ExerciseCategory
 
@@ -51,7 +63,6 @@ class ExerciseImageSerializer(serializers.ModelSerializer):
     '''
     ExerciseImage serializer
     '''
-
     class Meta:
         model = ExerciseImage
 
@@ -60,7 +71,6 @@ class ExerciseCommentSerializer(serializers.ModelSerializer):
     '''
     ExerciseComment serializer
     '''
-
     class Meta:
         model = ExerciseComment
 
@@ -69,6 +79,5 @@ class MuscleSerializer(serializers.ModelSerializer):
     '''
     Muscle serializer
     '''
-
     class Meta:
         model = Muscle

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -47,8 +47,16 @@ class ExerciseInfoSerializer(serializers.ModelSerializer):
     Exercise info serialiser
     '''
 
+    image = serializers.StringRelatedField(
+        source='get_exercise_image', many=True
+    )
+    description = serializers.ReadOnlyField(source='description_clean')
+
     class Meta:
         model = Exercise
+        fields = ('id', 'name', 'name_original', 'category', 'equipment',
+                  'description', 'muscles', 'muscles_secondary', 'image',
+                  'language', 'license', 'license_author', 'creation_date')
 
 
 class ExerciseCategorySerializer(serializers.ModelSerializer):

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -28,7 +28,8 @@ from django.utils.translation import ugettext as _
 from wger.config.models import LanguageConfig
 from wger.exercises.api.serializers import (
     MuscleSerializer, ExerciseSerializer, ExerciseImageSerializer,
-    ExerciseCategorySerializer, EquipmentSerializer, ExerciseCommentSerializer)
+    ExerciseCategorySerializer, EquipmentSerializer, ExerciseCommentSerializer,
+    ExerciseInfoSerializer)
 from wger.exercises.models import (Exercise, Equipment, ExerciseCategory,
                                    ExerciseImage, ExerciseComment, Muscle)
 from wger.utils.language import load_item_languages, load_language
@@ -56,6 +57,15 @@ class ExerciseViewSet(viewsets.ModelViewSet):
         # Todo is it right to call set author after save?
         obj.set_author(self.request)
         obj.save()
+
+
+class ExerciseInfoViewSet(viewsets.ReadOnlyModelViewSet):
+    '''
+    API endpoint for viewing all exercise info
+    '''
+    queryset = Exercise.objects.all()
+    serializer_class = ExerciseInfoSerializer
+    ordering_fields = '__all__'
 
 
 @api_view(['GET'])

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -379,7 +379,6 @@ class ExerciseImage(AbstractSubmissionModel, AbstractLicenseModel,
 
     exercise = models.ForeignKey(Exercise, verbose_name=_('Exercise'))
     '''The exercise the image belongs to'''
-    
     image = models.ImageField(
         verbose_name=_('Image'),
         help_text=_('Only PNG and JPEG formats are supported'),

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -291,6 +291,12 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
         '''
         return self.exerciseimage_set.accepted().filter(is_main=True).first()
 
+    def get_exercise_image(self):
+        '''
+        Return the main image for the exercise or None if nothing is found
+        '''
+        return self.exerciseimage_set.all()
+
     @property
     def description_clean(self):
         '''
@@ -373,7 +379,7 @@ class ExerciseImage(AbstractSubmissionModel, AbstractLicenseModel,
 
     exercise = models.ForeignKey(Exercise, verbose_name=_('Exercise'))
     '''The exercise the image belongs to'''
-
+    
     image = models.ImageField(
         verbose_name=_('Image'),
         help_text=_('Only PNG and JPEG formats are supported'),
@@ -423,6 +429,9 @@ class ExerciseImage(AbstractSubmissionModel, AbstractLicenseModel,
 
         # And go on
         super(ExerciseImage, self).save(*args, **kwargs)
+
+    def __str__(self):
+        return '%s' % (self.image)
 
     def delete(self, *args, **kwargs):
         '''

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -111,7 +111,8 @@ router.register(
 router.register(
     r'daysofweek', core_api_views.DaysOfWeekViewSet, base_name='daysofweek')
 router.register(r'license', core_api_views.LicenseViewSet, base_name='license')
-router.register(r'register-user', core_api_views.UserViewSet, base_name='register-user')
+router.register(r'register-user', core_api_views.UserViewSet,
+                base_name='register-user')
 router.register(
     r'setting-repetitionunit',
     core_api_views.RepetitionUnitViewSet,

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -125,6 +125,9 @@ router.register(
 router.register(
     r'exercise', exercises_api_views.ExerciseViewSet, base_name='exercise')
 router.register(
+    r'exerciseinfo', exercises_api_views.ExerciseInfoViewSet,
+    base_name='exerciseinfo')
+router.register(
     r'equipment', exercises_api_views.EquipmentViewSet, base_name='api')
 router.register(
     r'exercisecategory',


### PR DESCRIPTION
#### What does this PR do?
Show all information for an exercise

#### Description of Task to be completed?
creates a new read-only API endpoint that collects all the information of an exercise such as muscles, category, images, etc. This makes it easier for clients to get all the info since only a single request is needed to be done

#### How should this be manually tested?
Start the server
``` ./manage.py runserver```

Then open the URL of exerciseinfo endpoint to see all exercises
``` http://127.0.0.1:8000/api/v2/exerciseinfo/```

Specify exercise ID to view an individual exercise i.e
```http://127.0.0.1:8000/api/v2/exerciseinfo/344/```

#### What are the relevant pivotal tracker stories?
[#158626097](https://www.pivotaltracker.com/story/show/158626097)

#### Screenshots 
<img width="749" alt="screen shot 2018-07-11 at 15 21 16" src="https://user-images.githubusercontent.com/20478530/42570950-3b20272c-851e-11e8-865d-a1eaa6f8c243.png">
