### PR TITLE
#159059178 Ft add exercise info names

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -54,7 +54,9 @@ if DEBUG:
 
 # Sender address used for sent emails
 WGER_SETTINGS['EMAIL_FROM'] = 'wger Workout Manager <wger@example.com>'
-
+REST_FRAMEWORK = {
+    'EXCEPTION_HANDLER': 'wger.exercises.api.views.custom404'
+}
 # Your twitter handle, if you have one for this instance.
 #WGER_SETTINGS['TWITTER'] = ''
 

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -50,6 +50,12 @@ class ExerciseInfoSerializer(serializers.ModelSerializer):
         source='get_exercise_image', many=True
     )
     description = serializers.ReadOnlyField(source='description_clean')
+    muscles = serializers.StringRelatedField(many=True)
+    language = serializers.StringRelatedField(many=False)
+    category = serializers.StringRelatedField()
+    equipment = serializers.StringRelatedField(many=True)
+    muscles_secondary = serializers.StringRelatedField(many=True)
+    license = serializers.StringRelatedField()
 
     class Meta:
         model = Exercise

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -16,6 +16,7 @@
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
 from rest_framework import viewsets
+from rest_framework.views import exception_handler
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.decorators import detail_route, api_view
@@ -66,6 +67,15 @@ class ExerciseInfoViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Exercise.objects.all()
     serializer_class = ExerciseInfoSerializer
     ordering_fields = '__all__'
+
+
+def custom404(exc, context):
+    response = exception_handler(exc, context)
+    if response.status_code == 404:
+
+        return Response({
+            'detail': 'The exercise of that Id is not available'
+        })
 
 
 @api_view(['GET'])


### PR DESCRIPTION
#### What does this PR do?
Add names to exercise information

#### Description of Task to be completed?
Update exercise information to display names instead of ids i.e muscles, equipment, category and languages
Update response when exercise ID is not found

#### How should this be manually tested?
Accessing exercise information endpoint and specify the id
``` http://127.0.0.1:8000/api/v2/exerciseinfo/344/```

use a non-existent ID to view the updated error displayed
``` http://127.0.0.1:8000/api/v2/exerciseinfo/3448/```

#### What are the relevant pivotal tracker stories?
[#159059178](https://www.pivotaltracker.com/story/show/159059178)

#### Screenshots
<img width="738" alt="existing" src="https://user-images.githubusercontent.com/20478530/42750836-6072fc94-88f1-11e8-9348-992d3fea83ed.png">
<img width="724" alt="non-existent" src="https://user-images.githubusercontent.com/20478530/42750841-629a2f9c-88f1-11e8-85a7-3bc05eb0983c.png">
